### PR TITLE
Fix undefined local variable error output directory is not created

### DIFF
--- a/lib/fluent/diagtool/diagutils.rb
+++ b/lib/fluent/diagtool/diagutils.rb
@@ -229,7 +229,7 @@ module Diagtool
           if Dir.exist?(params[:output])
             options[:basedir] = params[:output]
           else
-            raise "output directory '#{basedir}' does not exist"
+            raise "output directory '#{params[:output]}' does not exist"
           end
         else
           raise "output directory '-o' must be specified"


### PR DESCRIPTION
It is reproducible by fluent-diagtool -t fluentd -o nonexistent:

```
  NameError: undefined local variable or method `basedir' for #<Diagtool::DiagUtils:0x00007f8dc3f75820 @time_format="20230822122658">

            raise "output directory '#{basedir}' does not exist"
                                       ^^^^^^^
  /work/fluent/fluentd/fluent-diagtool/lib/fluent/diagtool/diagutils.rb:232:in `parse_diagconf'
  /work/fluent/fluentd/fluent-diagtool/lib/fluent/diagtool/diagutils.rb:29:in `initialize'
  /work/fluent/fluentd/fluent-diagtool/exe/fluent-diagtool:40:in `new'
  /work/fluent/fluentd/fluent-diagtool/exe/fluent-diagtool:40:in `<top (required)>'
```