### PR TITLE
Fix undefined local variables @oslog, @syslog

### DIFF
--- a/lib/fluent/diagtool/collectutils.rb
+++ b/lib/fluent/diagtool/collectutils.rb
@@ -365,7 +365,7 @@ module Diagtool
         FileUtils.cp(@oslog_path+@syslog, target_dir)
         return target_dir+@syslog
       else
-        @logger.warn("Can not find OS log file in #{oslog} or #{syslog}")
+        @logger.warn("Can not find OS log file in #{@oslog} or #{@syslog}")
       end
     end
 


### PR DESCRIPTION
It can be reproduced with fluent-diaglool -t fluentd -o tmp

```
  NameError: undefined local variable or method `oslog' for
  #<Diagtool::CollectUtils:0x00007f33916c1f08
  #@logger=#<Logger:0x00007f33916c1d28...

  @logger.warn("Can not find OS log file in #{oslog} or #{syslog}")
  Did you mean?  @oslog
```
