### PR TITLE
Collect bundled plugin and locally added gem

### DIFF
--- a/lib/fluent/diagtool/diagutils.rb
+++ b/lib/fluent/diagtool/diagutils.rb
@@ -127,6 +127,17 @@ module Diagtool
       tdgem = c.collect_tdgems()
       diaglogger_info("[Collect] #{@conf[:package_name]} gem information is stored in #{tdgem}")
 
+      gem_info = c.collect_manually_installed_gems(tdgem)
+      diaglogger_info("[Collect] #{@conf[:package_name]} gem information (bundled by default) is stored in #{gem_info[:bundled]}")
+      diaglogger_info("[Collect] #{@conf[:package_name]} manually installed gem information is stored in #{gem_info[:local]}")
+      local_gems = File.read(gem_info[:local]).lines(chomp: true)
+      unless local_gems == [""]
+        diaglogger_info("[Collect] #{@conf[:package_name]} manually installed gems:")
+        local_gems.each do |gem|
+          diaglogger_info("[Collect]   * #{gem}")
+        end
+      end
+
       diaglogger_info("[Collect] Collecting config file of OS log...")
       oslog = c.collect_oslog()
       if @conf[:mask] == 'yes'


### PR DESCRIPTION
It is useful to detect additionally installed plugin.

Case 1: planning to migrate from td-agent to fluent-package. manually installed plugin must reinstall for fluent-package. so collect such information by fluent-diagtool.

 [Diagtool] [INFO] [Collect] Collecting fluent-package gem information...
 [Diagtool] [INFO] [Collect] fluent-package gem information is stored in tmp/20230901075350/output/tdgem_list.output
 [Diagtool] [INFO] [Collect] fluent-package gem information (bundled by default) is stored in tmp/20230901075350/output/gem_bundled_list.output
 [Diagtool] [INFO] [Collect] fluent-package manually installed gem information is stored in tmp/20230901075350/output/gem_local_list.output
 [Diagtool] [INFO] [Collect] fluent-package manually installed gems:
 [Diagtool] [INFO] [Collect]   * fluent-plugin-concat