### PR TITLE
Support windows partially

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The scope of data collection:
 <br>   
 
 ## Prerequisite
-Diagtool has been developed for Fluentd(td-agent) and FluentBit(td-agent-bit) running on Linux OS and Diatool does not work for Windows.
+Diagtool has been developed for Fluentd(td-agent, fluent-package) and FluentBit(td-agent-bit) running on Linux OS, mainly.
+On Windows, it only supports the `installed td-agent-gem list` collection for Fluentd, currently (since v1.0.3).
 Diagtool is written in Ruby and Ruby version should be higher than 2.3 for the installation. 
 The supported Linux OS is described in the following page:  
 https://docs.fluentd.org/quickstart/td-agent-v2-vs-v3-vs-v4
@@ -64,7 +65,13 @@ Usage: fluent-diagtool -o OUTPUT_DIR -m {yes | no} -w {word1,[word2...]} -f {lis
     -c, --conf config_file           provide a full path of td-agent configuration file (Optional : Default=None)
     -l, --log log_file               provide a full path of td-agent log file (Optional : Default=None)
 ```
+
+On Windows, only the `-o, --output DIR` option is supported.
+
 ### Precheck
+
+(Not supported on Windows)
+
 In order to run Diagtool correctly, it is required to ensure that Diagtool can obtain the fundamental information of Fluentd. Basically, Diagtool automatically parses the required information from the running Fluentd processes. The precheck option is useful to confirm if Diagtool certainly collects the information as expected. 
 The following output example shows the case where Diatool properly collects the required information.
 
@@ -162,6 +169,21 @@ Once the pre-check is completed, you are ready to run the tool. The “-o” is 
 2020-10-07 21:29:30 +0000: [Diagtool] [INFO] [Collect] Generate tar file /tmp/diagout-20201007212928.tar.gz
 ```
 
+fluent-package (td-agent) on Windows: Fluent Package Command Prompt (Td-agent Command Prompt) with Administrator privilege
+
+```
+$ fluent-diagtool -o /opt
+2023-11-21 12:46:08 +0900: [Diagtool] [INFO] Parsing command options...
+2023-11-21 12:46:08 +0900: [Diagtool] [INFO]    Option : Output directory = /opt
+2023-11-21 12:46:08 +0900: [Diagtool] [INFO] Initializing parameters...
+2023-11-21 12:46:08 +0900: [Diagtool] [INFO] [Collect] Collecting fluent-package gem information...
+2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect] fluent-package gem information is stored in /opt/20231121124608/output/tdgem_list.output
+2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect] fluent-package gem information (bundled by default) is stored in /opt/20231121124608/output/gem_bundled_list.output
+2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect] fluent-package manually installed gem information is stored in /opt/20231121124608/output/gem_local_list.output
+2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect] fluent-package manually installed gems:
+2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect]   * fluent-plugin-forest
+```
+
 #### The "@include" directive in td-agent configuration file
 The "@include" directive is a function to reuse configuration defined in other configuration files. Diagtool reads Fluentd configuration and gathers the files described in "@include" directive as well. The details of "@include" directive are described in followed page:  
 https://docs.fluentd.org/configuration/config-file#6-re-use-your-config-the-include-directive
@@ -203,7 +225,7 @@ The diagtool provides a hash-seed option with '-s'. When hash-seed is specified,
 ```
 
 ## Tested Environment
-- OS : CentOS 8.1 / Ubuntu 20.04
+- OS : CentOS 8.1 / Ubuntu 20.04 / Windows Home 10
 - Fluentd : td-agent version 3/4
   https://docs.fluentd.org/quickstart/td-agent-v2-vs-v3-vs-v4
 - Fluentd : fluent-package version 5

--- a/exe/fluent-diagtool
+++ b/exe/fluent-diagtool
@@ -17,9 +17,6 @@
 #
 
 require 'optparse'
-require 'fluent/diagtool/collectutils'
-require 'fluent/diagtool/maskutils'
-require 'fluent/diagtool/validutils'
 require 'fluent/diagtool/diagutils'
 include Diagtool
 

--- a/lib/fluent/diagtool/diagutils.rb
+++ b/lib/fluent/diagtool/diagutils.rb
@@ -14,15 +14,31 @@
 #    limitations under the License.
 #
 
+module Diagtool
+  ON_WINDOWS = /mingw/.match?(RUBY_PLATFORM)
+  def self.windows?
+    ON_WINDOWS
+  end
+end
+
 require 'logger'
 require 'fileutils'
 require 'fluent/diagtool/collectutils'
 require 'fluent/diagtool/maskutils'
 require 'fluent/diagtool/validutils'
+require 'fluent/diagtool/windows/diagutils' if Diagtool.windows?
 include Diagtool
 
 module Diagtool
   class DiagUtils
+    # TODO: Consider making the logic of this class more abstract and
+    # cutting out the unix-specific logic into a separate module as well.
+    # (Currently, very limited features are supported for Windows.
+    # In order to reduce impact on the existing logic for Unix-like.
+    # only Windows-specific logic is separated into the module, for now.
+    # In the future, the implementation of this class should be more abstract.)
+    prepend Windows::PlatformSpecificDiagUtils if Diagtool.windows?
+
     def initialize(params)
       time = Time.new
       @time_format = time.strftime("%Y%m%d%0k%M%0S")

--- a/lib/fluent/diagtool/windows/collectutils.rb
+++ b/lib/fluent/diagtool/windows/collectutils.rb
@@ -1,0 +1,34 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Diagtool
+  module Windows
+    module PlatformSpecificCollectUtils
+      def _find_fluentd_info()
+        # Not supported yet.
+      end
+
+      def _find_fluentbit_info()
+        # Not supported yet.
+      end
+
+      def _find_os_info()
+        # Not supported yet.
+        return {}
+      end
+    end
+  end
+end

--- a/lib/fluent/diagtool/windows/diagutils.rb
+++ b/lib/fluent/diagtool/windows/diagutils.rb
@@ -1,0 +1,97 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'logger'
+require 'fileutils'
+require 'fluent/diagtool/collectutils'
+
+module Diagtool
+  module Windows
+    module PlatformSpecificDiagUtils
+      def run_precheck()
+        raise "[Precheck] Precheck feature is not supported on Windows."
+      end
+
+      def run_diagtool()
+        @conf[:time] = @time_format
+        @conf[:workdir] = @conf[:basedir] + '/' + @time_format
+        @conf[:outdir] = @conf[:workdir] + '/output'
+        FileUtils.mkdir_p(@conf[:workdir])
+        FileUtils.mkdir_p(@conf[:outdir])
+        diaglog = @conf[:workdir] + '/diagtool.output'
+
+        @logger = Logger.new(STDOUT, formatter: proc {|severity, datetime, progname, msg|
+          "#{datetime}: [Diagtool] [#{severity}] #{msg}\n"
+        })
+        @logger_file = Logger.new(diaglog, formatter: proc {|severity, datetime, progname, msg|
+          "#{datetime}: [Diagtool] [#{severity}] #{msg}\n"
+        })
+        diaglogger_info("Parsing command options...")
+        diaglogger_info("   Option : Output directory = #{@conf[:basedir]}")
+
+        loglevel = 'WARN'
+        diaglogger_info("Initializing parameters...")
+        c = CollectUtils.new(@conf, loglevel)
+
+        diaglogger_info("[Collect] Collecting #{@conf[:package_name]} gem information...")
+        tdgem = c.collect_tdgems()
+        diaglogger_info("[Collect] #{@conf[:package_name]} gem information is stored in #{tdgem}")
+
+        gem_info = c.collect_manually_installed_gems(tdgem)
+        diaglogger_info("[Collect] #{@conf[:package_name]} gem information (bundled by default) is stored in #{gem_info[:bundled]}")
+        diaglogger_info("[Collect] #{@conf[:package_name]} manually installed gem information is stored in #{gem_info[:local]}")
+        local_gems = File.read(gem_info[:local]).lines(chomp: true)
+        unless local_gems == [""]
+          diaglogger_info("[Collect] #{@conf[:package_name]} manually installed gems:")
+          local_gems.each do |gem|
+            diaglogger_info("[Collect]   * #{gem}")
+          end
+        end
+      end
+
+      def parse_diagconf(params)
+        options = {
+          :precheck => '', :basedir => '', :type =>'', :mask => '', :words => [], :wfile => '', :seed => '', :tdconf =>'', :tdlog => ''
+        }
+
+        supported_options = [:type, :output]
+
+        unless params[:type] == nil || params[:type] == 'fluentd'
+          raise "fluentd type '-t' only supports 'fluentd' on Windows."
+        end
+        options[:type] = 'fluentd'
+
+        if params[:output] != nil
+          if Dir.exist?(params[:output])
+            options[:basedir] = params[:output]
+          else
+            raise "output directory '#{params[:output]}' does not exist"
+          end
+        else
+          raise "output directory '-o' must be specified"
+        end
+
+        params.keys.each do |option|
+          unless supported_options.include?(option)
+            raise "#{option} is not supported on Windows."
+          end
+        end
+
+        return options
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Add Windows support for #14

Only supports the `-o, --output DIR` option and the `installed td-agent-gem list` collection for Fluentd (fluent-package, td-agent).

fluent-package v5.0.1 on Windows: (Fluent Package Command Prompt with Administrator privilege)

```
$ fluent-diagtool -o /opt
2023-11-21 12:46:08 +0900: [Diagtool] [INFO] Parsing command options...
2023-11-21 12:46:08 +0900: [Diagtool] [INFO]    Option : Output directory = /opt
2023-11-21 12:46:08 +0900: [Diagtool] [INFO] Initializing parameters...
2023-11-21 12:46:08 +0900: [Diagtool] [INFO] [Collect] Collecting fluent-package gem information...
2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect] fluent-package gem information is stored in /opt/20231121124608/output/tdgem_list.output
2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect] fluent-package gem information (bundled by default) is stored in /opt/20231121124608/output/gem_bundled_list.output
2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect] fluent-package manually installed gem information is stored in /opt/20231121124608/output/gem_local_list.output
2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect] fluent-package manually installed gems:
2023-11-21 12:46:10 +0900: [Diagtool] [INFO] [Collect]   * fluent-plugin-forest
```
