### PR TITLE
Make compatible for recent fluent-bit package

### DIFF
--- a/lib/fluent/diagtool/collectutils.rb
+++ b/lib/fluent/diagtool/collectutils.rb
@@ -157,10 +157,11 @@ module Diagtool
     
     def _find_fluentbit_info()
       ### check if the td-agent-bit is run as daemon
-      stdout, stderr, status = Open3.capture3('systemctl cat td-agent-bit')
+
+      stdout, _stderr, status = Open3.capture3("systemctl cat #{@service_name}")
       if status.success?
         if @precheck == false  # SKip if precheck is true
-          File.open(@outdir+'/td-agent-bit_env.output', 'w') do |f|
+          File.open(@outdir+"/#{@service_name}_env.output", 'w') do |f|
             f.puts(stdout)
           end
         end
@@ -184,8 +185,8 @@ module Diagtool
           end
         end
       else
-        ### check if the td-agent-bit is not run as daemon or run FluentdBit with customized script 
-        stdout, stderr, status = Open3.capture3('ps aux | grep fluent-bit | grep -v ".*\(grep\|diagtool\)"')
+        ### check if the td-agent-bit is not run as daemon or run FluentdBit with customized script
+        stdout, _stderr, status = Open3.capture3('ps aux | grep fluent-bit | grep -v ".*\(grep\|diagtool\)"')
         if status.success?
           i = 0
           stdout.split().each do | line |

--- a/lib/fluent/diagtool/diagutils.rb
+++ b/lib/fluent/diagtool/diagutils.rb
@@ -147,7 +147,7 @@ module Diagtool
       tdconf = c.collect_tdconf()
       diaglogger_info("[Collect] config file is stored in #{tdconf}")
 
-      case @type
+      case @conf[:type]
       when 'fluentd'
         diaglogger_info("[Collect] Collecting #{@conf[:package_name]} gem information...")
         tdgem = c.collect_tdgems()

--- a/lib/fluent/diagtool/diagutils.rb
+++ b/lib/fluent/diagtool/diagutils.rb
@@ -162,7 +162,7 @@ module Diagtool
             diaglogger_info("[Collect]   * #{gem}")
           end
         end
-      when 'fleuntbit'
+      when 'fluentbit'
         # nothing to do!
       end
 

--- a/lib/fluent/diagtool/diagutils.rb
+++ b/lib/fluent/diagtool/diagutils.rb
@@ -49,20 +49,22 @@ module Diagtool
 	      "netstat -plan",
 	      "netstat -s",
       ]
-      if @conf[:type].downcase == "fluentd" && fluent_package?
-        @conf[:package_name] = "fluent-package"
-        @conf[:service_name] = "fluentd"
+      if @conf[:type] == "fluentd"
+        if fluent_package?
+          @conf[:package_name] = "fluent-package"
+          @conf[:service_name] = "fluentd"
+        else
+          @conf[:package_name] = "td-agent"
+          @conf[:service_name] = "td-agent"
+        end
       else
-        @conf[:package_name] = "td-agent"
-        @conf[:service_name] = "td-agent"
-      end
-
-      if @conf[:type].downcase == "fluentbit" && fluentbit_package?
-        @conf[:package_name] = "fluent-bit"
-        @conf[:service_name] = "fluent-bit"
-      else
-        @conf[:package_name] = "td-agent-bit"
-        @conf[:service_name] = "td-agent-bit"
+        if fluentbit_package?
+          @conf[:package_name] = "fluent-bit"
+          @conf[:service_name] = "fluent-bit"
+        else
+          @conf[:package_name] = "td-agent-bit"
+          @conf[:service_name] = "td-agent-bit"
+        end
       end
     end
     


### PR DESCRIPTION
We already hadn't been used td-agent-bit name for fluent-bit package.
Instead, we use fluent-bit instead of it.

Also, Diagtool::CollectUtils#collect_tdgems is only works for td-agent/fluent-package. So, we have to disable when fluentbit type is used.

After applied these changes, diagtool should be exit normally:

```log
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] Parsing command options...
2023-11-30 18:09:59 +0900: [Diagtool] [INFO]    Option : Output directory = result
2023-11-30 18:09:59 +0900: [Diagtool] [INFO]    Option : Mask = yes
2023-11-30 18:09:59 +0900: [Diagtool] [INFO]    Option : Word list = []
2023-11-30 18:09:59 +0900: [Diagtool] [INFO]    Option : Hash Seed = 
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] Initializing parameters...
2023-11-30 18:09:59 +0900: [Collectutils] [WARN] FluentBit logs are redirected to the standard output interface 
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] Loading the environment parameters...
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect]    operating system = Ubuntu 20.04.6 LTS
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect]    kernel version = Linux 5.15.0-88-generic
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect]    fluent-bit conf path = //etc/fluent-bit/
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect]    fluent-bit conf file = fluent-bit.conf
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect]    fluent-bit log path = 
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect]    fluent-bit log = 
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] Collecting log files of fluent-bit...
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] Collecting config file of fluent-bit...
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] config file is stored in ["result/20231130180959//etc/fluent-bit/fluent-bit.conf", "result/20231130180959//etc/fluent-bit/parsers.conf", "result/20231130180959//etc/fluent-bit/plugins.conf"]
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] Collecting config file of OS log...
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Mask] Masking OS log file : result/20231130180959/var/log/syslog...
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] config file is stored in result/20231130180959/var/log/syslog.mask
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] Collecting date/time information...
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] date/time information is stored in result/20231130180959/output/ntpq_-p.txt
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Collect] Collecting command output : command = ps -eo pid,ppid,stime,time,%mem,%cpu,cmd
2023-11-30 18:09:59 +0900: [Diagtool] [INFO] [Mask] Masking command output file : result/20231130180959/output/ps_-eo_pid_ppid_stime_time_%mem_%cpu_cmd.txt...
2023-11-30 18:10:00 +0900: [Diagtool] [INFO] [Collect] Collecting command output ps stored in result/20231130180959/output/ps_-eo_pid_ppid_stime_time_%mem_%cpu_cmd.txt.mask
2023-11-30 18:10:00 +0900: [Diagtool] [INFO] [Collect] Collecting command output : command = cat /proc/meminfo
2023-11-30 18:10:00 +0900: [Diagtool] [INFO] [Mask] Masking command output file : result/20231130180959/output/cat_-proc-meminfo.txt...
2023-11-30 18:10:00 +0900: [Diagtool] [INFO] [Collect] Collecting command output cat stored in result/20231130180959/output/cat_-proc-meminfo.txt.mask
2023-11-30 18:10:00 +0900: [Diagtool] [INFO] [Collect] Collecting command output : command = netstat -plan
2023-11-30 18:10:00 +0900: [Diagtool] [INFO] [Mask] Masking command output file : result/20231130180959/output/netstat_-plan.txt...
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Collect] Collecting command output netstat stored in result/20231130180959/output/netstat_-plan.txt.mask
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Collect] Collecting command output : command = netstat -s
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Mask] Masking command output file : result/20231130180959/output/netstat_-s.txt...
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Collect] Collecting command output netstat stored in result/20231130180959/output/netstat_-s.txt.mask
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Collect] Collecting sysctl information...
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Collect] sysctl information is stored in result/20231130180959/output/sysctl_-a.txt
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Valid] Validating sysctl information...
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_core_netdev_max_backlog => 1000 is incorrect, should be 5000
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_core_rmem_max => 212992 is incorrect, should be 16777216
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_core_somaxconn => 4096 is incorrect, should be 1024
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_core_wmem_max => 212992 is incorrect, should be 16777216
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_ipv4_ip_local_port_range => ["32768", "60999"] is incorrect, should be ["10240", "65535"]
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_ipv4_tcp_max_syn_backlog => 4096 is incorrect, should be 8096
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_ipv4_tcp_rmem => ["4096", "131072", "6291456"] is incorrect, should be ["4096", "12582912", "16777216"]
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_ipv4_tcp_slow_start_after_idle => 1 is incorrect, should be 0
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_ipv4_tcp_tw_reuse => 2 is incorrect, should be 1
2023-11-30 18:10:01 +0900: [Validutils] [WARN] net_ipv4_tcp_wmem => ["4096", "16384", "4194304"] is incorrect, should be ["4096", "12582912", "16777216"]
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_core_netdev_max_backlog => 1000 is incorrect (recommendation is 5000)
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_core_rmem_max => 212992 is incorrect (recommendation is 16777216)
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_core_somaxconn => 4096 is incorrect (recommendation is 1024)
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_core_wmem_max => 212992 is incorrect (recommendation is 16777216)
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_ipv4_ip_local_port_range => ["32768", "60999"] is incorrect (recommendation is ["10240", "65535"])
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_ipv4_tcp_max_syn_backlog => 4096 is incorrect (recommendation is 8096)
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_ipv4_tcp_rmem => ["4096", "131072", "6291456"] is incorrect (recommendation is ["4096", "12582912", "16777216"])
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_ipv4_tcp_slow_start_after_idle => 1 is incorrect (recommendation is 0)
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_ipv4_tcp_tw_reuse => 2 is incorrect (recommendation is 1)
2023-11-30 18:10:01 +0900: [Diagtool] [WARN] [Valid]    Sysctl: net_ipv4_tcp_wmem => ["4096", "16384", "4194304"] is incorrect (recommendation is ["4096", "12582912", "16777216"])
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Collect] Collecting ulimit information...
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Collect] ulimit information is stored in result/20231130180959/output/sh_-c_'ulimit_-n'.txt
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Valid] Validating ulimit information...
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Valid]    ulimit => 65535 is correct (recommendation is >65535)
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Mask] Masking fluent-bit config file : result/20231130180959//etc/fluent-bit/fluent-bit.conf...
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Mask] Masking fluent-bit config file : result/20231130180959//etc/fluent-bit/parsers.conf...
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Mask] Masking fluent-bit config file : result/20231130180959//etc/fluent-bit/plugins.conf...
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Mask] Export mask log file : ./mask_20231130180959.json
2023-11-30 18:10:01 +0900: [Diagtool] [INFO] [Collect] Generate tar file result/diagout-20231130180959.tar.gz
```