### PR TITLE
Don't raise exception when sysctl is not ready

### DIFF
--- a/lib/fluent/diagtool/diagutils.rb
+++ b/lib/fluent/diagtool/diagutils.rb
@@ -207,16 +207,18 @@ module Diagtool
       ###
       diaglogger_info("[Collect] Collecting sysctl information...")
       sysctl = c.collect_cmd_output("sysctl -a")
-      diaglogger_info("[Collect] sysctl information is stored in #{sysctl}")
-			
-      diaglogger_info("[Valid] Validating sysctl information...")
-      ret, sysctl = v.valid_sysctl(sysctl)
-      list =  sysctl.keys
-      list.each do |k|
-        if sysctl[k]['result'] == 'correct'
-          diaglogger_info("[Valid]    Sysctl: #{k} => #{sysctl[k]['value']} is correct (recommendation is #{sysctl[k]['recommend']})")
-        elsif sysctl[k]['result'] == 'incorrect'
-          diaglogger_warn("[Valid]    Sysctl: #{k} => #{sysctl[k]['value']} is incorrect (recommendation is #{sysctl[k]['recommend']})")
+      if sysctl
+        diaglogger_info("[Collect] sysctl information is stored in #{sysctl}")
+
+        diaglogger_info("[Valid] Validating sysctl information...")
+        ret, sysctl = v.valid_sysctl(sysctl)
+        list =  sysctl.keys
+        list.each do |k|
+          if sysctl[k]['result'] == 'correct'
+            diaglogger_info("[Valid]    Sysctl: #{k} => #{sysctl[k]['value']} is correct (recommendation is #{sysctl[k]['recommend']})")
+          elsif sysctl[k]['result'] == 'incorrect'
+            diaglogger_warn("[Valid]    Sysctl: #{k} => #{sysctl[k]['value']} is incorrect (recommendation is #{sysctl[k]['recommend']})")
+          end
         end
       end
 


### PR DESCRIPTION
When /usr/sbin/sysctl is not available, it emits "[WARN] Command sysctl -a" does not exist.

That behavior is ok, but it should not raise exception by passing nil to readlines here.

Before:

  /opt/fluent/lib/ruby/gems/3.2.0/gems/fluent-diagtool-1.0.4/lib/fluent/diagtool/validutils.rb:60:in
  `readlines': no implicit conversion of nil into String (TypeError)

      File.readlines(sysctl_file).each{ |line|
                     ^^^^^^^^^^^
	from /opt/fluent/lib/ruby/gems/3.2.0/gems/fluent-diagtool-1.0.4/lib/fluent/diagtool/validutils.rb:60:in `valid_sysctl'
	from /opt/fluent/lib/ruby/gems/3.2.0/gems/fluent-diagtool-1.0.4/lib/fluent/diagtool/diagutils.rb:213:in `run_diagtool'
	from /opt/fluent/lib/ruby/gems/3.2.0/gems/fluent-diagtool-1.0.4/exe/fluent-diagtool:41:in `<top (required)>'
	from /opt/fluent/bin/fluent-diagtool:25:in `load'
	from /opt/fluent/bin/fluent-diagtool:25:in `<main>'
  [Collectutils] [WARN] Command sysctl -a does not exist -  skip collecting sysctl -a output

After:

  [Diagtool] [INFO] [Collect] Collecting sysctl information...
  [Collectutils] [WARN] Command sysctl2 -a does not exist -  skip collecting sysctl2 -a output
  [Diagtool] [INFO] [Collect] sysctl information is stored in
  [Diagtool] [INFO] [Valid] Validating sysctl information...
  [Diagtool] [INFO] [Collect] Collecting ulimit information...
  [Diagtool] [INFO] [Collect] ulimit information is stored in /tmp/20240318063926/output/sh_-c_'ulimit_-n'.txt
  [Diagtool] [INFO] [Valid] Validating ulimit information...
  [Validutils] [WARN]     ulimit => 1024 is incorrect, should be 65535
  [Diagtool] [WARN] [Valid]    ulimit => 1024 is incorrect (recommendation is >65535)
  [Diagtool] [INFO] [Collect] Generate tar file /tmp/diagout-20240318063926.tar.gz